### PR TITLE
rename Window to WindowModeWindow to fix compilation error

### DIFF
--- a/Sources/Shader.cpp
+++ b/Sources/Shader.cpp
@@ -42,7 +42,7 @@ int kore(int argc, char** argv) {
 	options.x = 100;
 	options.y = 100;
 	options.targetDisplay = -1;
-	options.mode = WindowMode::Window;
+	options.mode = WindowMode::WindowModeWindow;
 	options.rendererOptions.depthBufferBits = 16;
 	options.rendererOptions.stencilBufferBits = 8;
 	options.rendererOptions.textureFormat = 0;


### PR DESCRIPTION
Hello, 
The sample didn't compile for me.
This commit seems to fix it
